### PR TITLE
Correct permissions on /staff and /dataset-providers

### DIFF
--- a/src/main/java/org/veupathdb/service/access/controller/StaffController.java
+++ b/src/main/java/org/veupathdb/service/access/controller/StaffController.java
@@ -25,7 +25,7 @@ public class StaffController implements Staff
 
   @Override
   public GetStaffResponse getStaff(final int limit, final int offset) {
-    if (!StaffService.userIsOwner(request))
+    if (!StaffService.userIsStaff(request))
       throw new ForbiddenException();
 
     return GetStaffResponse.respond200WithApplicationJson(

--- a/src/main/java/org/veupathdb/service/access/service/provider/ProviderService.java
+++ b/src/main/java/org/veupathdb/service/access/service/provider/ProviderService.java
@@ -100,13 +100,13 @@ public class ProviderService
 
       // Determine if the user is a manager for the dataset.
       for (var pro : rows) {
-        if (pro.getUserId() == currentUser.getUserId() && pro.isManager()) {
+        if (pro.getUserId() == currentUser.getUserId()) {
           allowed = true;
           break;
         }
       }
 
-      if (StaffService.userIsOwner(currentUser.getUserId()))
+      if (StaffService.userIsStaff(currentUser.getUserId()))
         allowed = true;
 
       if (!allowed)

--- a/src/main/java/org/veupathdb/service/access/service/staff/StaffService.java
+++ b/src/main/java/org/veupathdb/service/access/service/staff/StaffService.java
@@ -43,6 +43,22 @@ public class StaffService
     return getInstance().isUserOwner(req);
   }
 
+  public static boolean userIsStaff(final Request req) {
+    return getInstance().isUserStaff(req);
+  }
+
+  public boolean isUserStaff(final Request req) {
+    log.trace("StaffService#isUserStaff(Request)");
+
+    return isUserStaff(UserProvider.lookupUser(req)
+      .orElseThrow(InternalServerErrorException::new)
+      .getUserId());
+  }
+
+  public static boolean userIsStaff(final long id) {
+    return getInstance().isUserStaff(id);
+  }
+
   public boolean isUserStaff(final long userId) {
     log.trace("StaffService#isUserStaff(long)");
 


### PR DESCRIPTION
Adjusted permission calls where the checks are performed and added an additional utility method to check if as user is staff based on the request.

Closes #37