### PR TITLE
Add "allowEdit" field to end user

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -56,6 +56,7 @@ types:
       approvalStatus: ApprovalStatus
       denialReason?: string
       priorAuth: string
+      allowEdit: boolean
   EndUserCreateRequest:
     description: |
       New end user request body.

--- a/schema/url/dataset-end-users.raml
+++ b/schema/url/dataset-end-users.raml
@@ -21,6 +21,7 @@ types:
       approvalStatus: lib.ApprovalStatus
       denialReason?: string
       priorAuth: string
+      allowEdit: boolean
     additionalProperties: false
 
   EndUserCreateRequest:

--- a/src/main/java/org/veupathdb/service/access/service/user/EndUserUtil.java
+++ b/src/main/java/org/veupathdb/service/access/service/user/EndUserUtil.java
@@ -240,6 +240,7 @@ public class EndUserUtil
     out.setRestrictionLevel(convertRestriction(row.getRestrictionLevel()));
     out.setStartDate(Date.from(row.getStartDate().toInstant()));
     out.setPriorAuth(row.getPriorAuth());
+    out.setAllowEdit(row.isAllowSelfEdits());
 
     return out;
   }


### PR DESCRIPTION
Plumbing the allowEdit field from database to response.

## Testing
* GET https://edadata-dev.local.apidb.org:8443/dataset-end-users
* Verified response of my test request that I denied:
```
{
            "user": {
                "userId": 400455250,
                "firstName": "Daniel",
                "lastName": "Galdi",
                "organization": "Unaffiliated",
                "email": "dmgaldi@gmail.com"
            },
            "datasetId": "DS_a885240fc4",
            "startDate": "2023-06-07T04:00:00.000Z",
            "duration": -1,
            "restrictionLevel": "public",
            "purpose": "testing",
            "disseminationPlan": "testing",
            "approvalStatus": "denied",
            "allowEdit": true
}
```