### PR TITLE
Don't send approve/deny e-mails to support and reset apprvl after self-patch

### DIFF
--- a/src/main/java/org/veupathdb/service/access/service/email/EmailService.java
+++ b/src/main/java/org/veupathdb/service/access/service/email/EmailService.java
@@ -84,11 +84,7 @@ public class EmailService
     sendEmail(new Email()
         .setSubject(util.populateTemplate(template.getSubject(), dataset))
         .setBody(util.populateTemplate(template.getBody(), dataset, user))
-        .setTo(
-            Stream.concat(Arrays.stream(cc), Stream.of(Main.config.getSupportEmail()))
-                .distinct()
-                .toArray(String[]::new)
-        )
+        .setTo(cc)
         .setFrom(dataset.getProperties().get(Dataset.Property.REQUEST_EMAIL)));
   }
 
@@ -101,11 +97,7 @@ public class EmailService
     sendEmail(new Email()
         .setSubject(util.populateTemplate(template.getSubject(), dataset))
         .setBody(util.populateTemplate(template.getBody(), dataset, user))
-        .setTo(
-            Stream.concat(Arrays.stream(cc), Stream.of(Main.config.getSupportEmail()))
-                .distinct()
-                .toArray(String[]::new)
-        )
+        .setTo(cc)
         .setFrom(dataset.getProperties().get(Dataset.Property.REQUEST_EMAIL)));
   }
 

--- a/src/main/java/org/veupathdb/service/access/service/user/EndUserPatchService.java
+++ b/src/main/java/org/veupathdb/service/access/service/user/EndUserPatchService.java
@@ -85,6 +85,9 @@ public class EndUserPatchService
     // manager or provider stepping in to re-enable self edits.
     row.setAllowSelfEdits(false);
 
+    // Set approval status to requested when a self-patch is made.
+    row.setApprovalStatus(ApprovalStatus.REQUESTED);
+
     try {
       final var ds = DatasetRepo.Select.getInstance()
         .selectDataset(row.getDatasetId())


### PR DESCRIPTION
* Per slack thread, reset approval status whenever a user applies self-patch to an access request
* Do not send e-mails to support when access request is approved or denied