### PR TITLE
Source study manager emails from studyaccess tables instead of dataset properties to avoid redundancy

### DIFF
--- a/src/main/java/org/veupathdb/service/access/service/email/EmailService.java
+++ b/src/main/java/org/veupathdb/service/access/service/email/EmailService.java
@@ -32,10 +32,17 @@ public class EmailService
     final var template = Const.EndUserTemplate;
     final var util     = EmailUtil.getInstance();
 
+
     log.info("Sending email");
     sendEmail(new Email()
-      .setSubject(util.populateTemplate(template.getSubject(), dataset))
-      .setBody(util.populateTemplate(template.getBody(), dataset))
+      .setSubject(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+          .withDataset(dataset)
+          .withTemplate(template.getSubject())
+          .build()))
+      .setBody(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+          .withDataset(dataset)
+          .withTemplate(template.getBody())
+          .build()))
       .setFrom(dataset.getProperties().get(Dataset.Property.REQUEST_EMAIL))
       .setTo(new String[]{address}));
   }
@@ -48,8 +55,14 @@ public class EmailService
     final var util     = EmailUtil.getInstance();
 
     sendEmail(new Email()
-      .setSubject(util.populateTemplate(template.getSubject(), dataset))
-      .setBody(util.populateTemplate(template.getBody(), dataset))
+      .setSubject(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+          .withDataset(dataset)
+          .withTemplate(template.getSubject())
+          .build()))
+      .setBody(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+          .withDataset(dataset)
+          .withTemplate(template.getBody())
+          .build()))
       .setFrom(dataset.getProperties().get(Dataset.Property.REQUEST_EMAIL))
       .setTo(new String[]{address}));
   }
@@ -65,8 +78,15 @@ public class EmailService
     final var util     = EmailUtil.getInstance();
 
     sendEmail(new Email()
-      .setSubject(util.populateTemplate(template.getSubject(), dataset))
-      .setBody(util.populateTemplate(template.getBody(), dataset, user))
+      .setSubject(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+          .withDataset(dataset)
+          .withTemplate(template.getSubject())
+          .build()))
+      .setBody(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+          .withDataset(dataset)
+          .withTemplate(template.getBody())
+          .withEndUserRow(user)
+          .build()))
       .setTo(
         Stream.concat(Arrays.stream(cc), Stream.of(Main.config.getSupportEmail()))
           .distinct()
@@ -76,27 +96,45 @@ public class EmailService
   }
 
   public void sendDatasetApprovedNotificationEmail(final String[] cc,
-                                                  final Dataset dataset,
-                                                  final EndUserRow user) throws Exception {
+                                                   final Dataset dataset,
+                                                   final EndUserRow user,
+                                                   final String[] managerEmails) throws Exception {
     final var template = Const.ApproveNotification;
     final var util     = EmailUtil.getInstance();
 
     sendEmail(new Email()
-        .setSubject(util.populateTemplate(template.getSubject(), dataset))
-        .setBody(util.populateTemplate(template.getBody(), dataset, user))
+        .setSubject(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+            .withDataset(dataset)
+            .withTemplate(template.getSubject())
+            .build()))
+        .setBody(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+            .withDataset(dataset)
+            .withTemplate(template.getBody())
+            .withEndUserRow(user)
+            .withManagerEmails(managerEmails)
+            .build()))
         .setTo(cc)
         .setFrom(dataset.getProperties().get(Dataset.Property.REQUEST_EMAIL)));
   }
 
   public void sendDatasetDeniedNotificationEmail(final String[] cc,
                                                  final Dataset dataset,
-                                                 final EndUserRow user) throws Exception {
+                                                 final EndUserRow user,
+                                                 final String[] managerEmails) throws Exception {
     final var template = Const.DenyNotification;
     final var util     = EmailUtil.getInstance();
 
     sendEmail(new Email()
-        .setSubject(util.populateTemplate(template.getSubject(), dataset))
-        .setBody(util.populateTemplate(template.getBody(), dataset, user))
+        .setSubject(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+            .withDataset(dataset)
+            .withTemplate(template.getSubject())
+            .build()))
+        .setBody(util.populateTemplate(EmailUtil.TemplateInput.newBuilder()
+            .withDataset(dataset)
+            .withTemplate(template.getBody())
+            .withEndUserRow(user)
+            .withManagerEmails(managerEmails)
+            .build()))
         .setTo(cc)
         .setFrom(dataset.getProperties().get(Dataset.Property.REQUEST_EMAIL)));
   }

--- a/src/main/resources/email.yaml
+++ b/src/main/resources/email.yaml
@@ -53,4 +53,4 @@ approve-notification:
 deny-notification:
   subject: $dataset.displayName$ Access Request Denied
   body: |
-    Unfortunately, your request to access $dataset.displayName$ data on ClinEpiDB has been denied for the following reason: "$end-user.denialReason$". Please reach out to $dataset.requestEmailBcc$ for more information. Thank you!
+    Unfortunately, your request to access $dataset.displayName$ data on ClinEpiDB has been denied for the following reason: "$end-user.denialReason$". Please reach out to $manager-emails$ for more information. Thank you!


### PR DESCRIPTION
Small request from Danica/Nupur: https://github.com/VEuPathDB/EdaNewIssues/issues/671

## Overview
* Currently, study manager e-mails have to be redundantly specified in both:
  * StudyAccess tables by staff or other study managers
  * Dataset presenters by staff

This change updates the e-mail template to pull from StudyAccess instead of dataset properties to avoid the redundancy.